### PR TITLE
Shell is now configurable since zsh is not a default

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -21,6 +21,7 @@ const conf = require('rc')('stampede', {
   errorLogFile: 'stderr.log',
   responseQueue: 'stampede-response',
   environmentVariablePrefix: 'STAMP_',
+  shell: '/bin/bash',
 })
 
 const redisConfig = {
@@ -93,7 +94,7 @@ async function executeTask(workingDirectory, environment) {
       env: environment,
       encoding: 'utf8',
       stdio: ['ignore', stdoutlog, stderrlog],
-      shell: '/bin/zsh',
+      shell: conf.shell,
     }
 
     const spawned = spawn(conf.taskCommand, options)


### PR DESCRIPTION
/bin/bash is the default but you can change it with the `shell` config.

Closes #17 