### PR TITLE
Configurable log files

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -2,7 +2,6 @@
 'use strict'
 
 const chalk = require('chalk')
-const clear = require('clear')
 const figlet = require('figlet')
 const fs = require('fs')
 const { spawn } = require('child_process')
@@ -41,8 +40,7 @@ const redisConfig = {
   },
 }
 
-clear()
-console.log(chalk.red(figlet.textSync('stampede worker', {horizontalLayout: 'full'})))
+console.log(chalk.red(figlet.textSync('stampede', {horizontalLayout: 'full'})))
 console.log(chalk.red('Redis Host: ' + conf.redisHost))
 console.log(chalk.red('Redis Port: ' + conf.redisPort))
 console.log(chalk.red('Task Queue: ' + conf.taskQueue))


### PR DESCRIPTION
Now all the log files used by the worker are configurable. You can also explicitly set the files for the success summary & text output to GitHub, along with the error summary & text. Sane defaults are in place so you can also use those as well.