### PR TITLE
✨ New config option to save incoming messages

### DIFF
--- a/lib/queueLog.js
+++ b/lib/queueLog.js
@@ -1,0 +1,18 @@
+'use strict'
+const fs = require('fs')
+
+let messageCount = 0
+
+/**
+ * save
+ * @param {*} taskID
+ * @param {*} task
+ * @param {*} path
+ */
+async function save(taskID, task, path) {
+  messageCount = messageCount + 1
+  const fileName = path + '/' + taskID + '-' + messageCount.toString() + '.log'
+  fs.writeFileSync(fileName, JSON.stringify(task, null, 2))
+}
+
+module.exports.save = save

--- a/package-lock.json
+++ b/package-lock.json
@@ -586,6 +586,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -979,6 +985,16 @@
         }
       }
     },
+    "mock-require": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.3.tgz",
+      "integrity": "sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==",
+      "dev": true,
+      "requires": {
+        "get-caller-file": "1.0.3",
+        "normalize-path": "2.1.1"
+      }
+    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
@@ -1019,6 +1035,15 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-eta/-/node-eta-0.9.0.tgz",
       "integrity": "sha1-n7CwmbzSoCGUDmA8ZCVNwAPZp6g="
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
     },
     "object-inspect": {
       "version": "1.6.0",
@@ -1190,6 +1215,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "resolve-from": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     "figlet": "^1.2.1",
     "pkginfo": "^0.4.1",
     "rc": "^1.2.8",
-    "redis": "^2.8.0"
+    "redis": "^2.8.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "eslint": "^6.3.0",
     "eslint-config-strongloop": "^2.1.0",
     "mocha": "^5.2.0",
-    "chai": "^4.2.0"
+    "mock-require": "^3.0.3"
   }
 }

--- a/test/queueLog-tests.js
+++ b/test/queueLog-tests.js
@@ -1,0 +1,38 @@
+'use strict'
+/* eslint-env mocha */
+const expect = require('chai').expect
+const mock = require('mock-require')
+
+const someTask = {
+  id: 42,
+  title: 'Some task',
+}
+
+let writeFileSyncPath = null
+let writeFileSyncData = null
+
+mock('fs', {
+  writeFileSync: function(path, data) {
+    writeFileSyncPath = path
+    writeFileSyncData = data
+  },
+})
+
+const queueLog = require('../lib/queueLog')
+queueLog.save('a-task-id', someTask, '/path/to/log')
+
+mock.stop('fs')
+
+describe('Queue Log', function() {
+  beforeEach(() => {
+  })
+
+  it('should write a file if save is called', function() {
+    expect(writeFileSyncPath).to.not.equal(null)
+    expect(writeFileSyncData).to.not.equal(null)
+  })
+
+  it('should name the file correctly', function() {
+    expect(writeFileSyncPath).to.equal('/path/to/log/a-task-id-1.log')
+  })
+})


### PR DESCRIPTION
This PR adds a new config option that allows you to save all the incoming messages to a worker. This is helpful for debugging both what messages are coming into the worker, but also when you want to replay messages to a worker using `stampede-cli`.

Closes #33 