### PR TITLE
✨ Separate stderr log file optional

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -27,7 +27,7 @@ const conf = require('rc')('stampede', {
   gitClone: 'ssh',
   // Log file configuration
   stdoutLogFile: 'stdout.log',
-  stderrLogFile: 'stderr.log',
+  stderrLogFile: null,
   environmentLogFile: 'environment.log',
   taskDetailsLogFile: 'worker.log',
   successSummaryFile: null,


### PR DESCRIPTION
Now the separate stderr log file is optional. The default is now that logs will go into the single stdout.log file. Setting the `stderrLogFile` value will cause stderr to output to the separate file.

Closes #31 