### PR TITLE
✨ Shallow cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The configuration parameters are:
 | taskCommand | null | The command line to execute to process the task |
 | workspaceRoot | null | The root folder for executing the command in |
 | gitClone | ssh | If a git clone should be made before executing command for a task and the method. Values can be ssh or https. Any other value indicates no git clone will be required for the task |
+| gitCloneDepth | 1 | Determines if a shallow clone is performed. Set to null for a full clone |
 | errorLogFile | stderr.log | The name of the file to send as the summary for a failed task |
 | responseQueue | stampede-response | The name of the queue to send the task updates to |
 | environmentVariablePrefix | 'STAMP_' | The prefix for any environment variables |

--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -25,6 +25,7 @@ const conf = require('rc')('stampede', {
   environmentVariablePrefix: 'STAMP_',
   shell: '/bin/bash',
   gitClone: 'ssh',
+  gitCloneDepth: 1,
   // Log file configuration
   stdoutLogFile: 'stdout.log',
   stderrLogFile: null,
@@ -160,10 +161,10 @@ async function prepareWorkingDirectory(task) {
     console.log(chalk.green('--- performing a git clone from:'))
     if (conf.gitClone === 'ssh') {
       console.log(chalk.green(task.ssh_url))
-      await cloneRepo(task.ssh_url, dir)
+      await cloneRepo(task.ssh_url, dir, conf.gitCloneDepth)
     } else if (conf.gitClone === 'https') {
       console.log(chalk.green(task.clone_url))
-      await cloneRepo(task.clone_url, dir)
+      await cloneRepo(task.clone_url, dir, conf.gitCloneDepth)
     }
 
     // Handle pull requests differently
@@ -255,9 +256,12 @@ async function updateTask(task) {
  * @param {*} cloneUrl
  * @param {*} workingDirectory
  */
-async function cloneRepo(cloneUrl, workingDirectory) {
+async function cloneRepo(cloneUrl, workingDirectory, cloneDepth) {
   return new Promise(resolve => {
-    exec('git clone ' + cloneUrl + ' ' + workingDirectory, (error, stdout, stderr) => {
+    const depth = cloneDepth != null ?
+      ' --depth ' + cloneDepth + ' --no-single-branch '
+      : ''
+    exec('git clone ' + depth + cloneUrl + ' ' + workingDirectory, (error, stdout, stderr) => {
       if (error) {
         console.error(`cloneRepo error: ${error}`)
         // TODO: figure out the error reason


### PR DESCRIPTION
This PR makes the worker do a shallow clone by default. You can also specify a full clone by setting the `gitCloneDepth` property to null. Or you can set it to a specific depth. The default is 1.

Closes #26 