### PR TITLE
Added a worker section to task summary

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -78,7 +78,7 @@ async function handleTask(task) {
   task.status = 'in_progress'
   task.worker = {
     node: '',
-    version: module.exports.version
+    version: module.exports.version,
   }
   await updateTask(task)
 


### PR DESCRIPTION
This PR just adds in a worker section to the task summary and has a version key that includes the version of the `stampede-worker` app that ran the task. This will help debug which versions of the workers are executing tasks.

Closes #43 