### PR TITLE
✨ Added a node config property and including in task details

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -17,6 +17,7 @@ const conf = require('rc')('stampede', {
   redisHost: 'localhost',
   redisPort: 6379,
   redisPassword: null,
+  nodeName: 'missing-node-name',
   taskQueue: null,
   responseQueue: 'stampede-response',
   // Command configuration
@@ -77,7 +78,7 @@ async function handleTask(task) {
   console.dir(task)
   task.status = 'in_progress'
   task.worker = {
-    node: '',
+    node: conf.nodeName,
     version: module.exports.version,
   }
   await updateTask(task)


### PR DESCRIPTION
This PR adds a `nodeName` to the worker config and includes the node name in the task details so we can track which node a task is running or ran on.

Closes #44 