### PR TITLE
✅ Added a test mode to the worker

### DIFF
--- a/lib/responseTestFile.js
+++ b/lib/responseTestFile.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const fs = require('fs')
+
+let responseFileName = ''
+let responseCount = 0
+
+/**
+ * init
+ * @param {*} fileName
+ */
+async function init(fileName) {
+  responseFileName = fileName
+}
+
+/**
+ * add
+ * @param {*} task
+ */
+async function add(task) {
+  console.log('--- response test file add')
+  responseCount += 1
+  fs.writeFileSync(responseFileName + '-' + responseCount.toString() + '.log',
+    JSON.stringify(task, null, 2))
+}
+
+module.exports.init = init
+module.exports.add = add


### PR DESCRIPTION
This PR adds in a test mode to the worker by adding two new config properties: `taskTestFile` and `responseTestFile`.  Providing these will change the worker behavior so that instead of pulling tasks from a queue it will just load a single task from the `taskTestFile` and then output the task results to the `responseTestFile`.  Note that the worker will write 2 output files since there is an in progress state and then a completed state.

This can be used to test the workers behavior along with testing the task commands when they are executed from a worker.

Closes #53 