### PR TITLE
✨ Task can timeout now and spawned exec will be killed

### DIFF
--- a/lib/executionConfig.js
+++ b/lib/executionConfig.js
@@ -1,6 +1,6 @@
-'use strict';
-const fs = require('fs');
-const yaml = require('js-yaml');
+"use strict";
+const fs = require("fs");
+const yaml = require("js-yaml");
 
 /**
  * prepareExecutionConfig
@@ -9,21 +9,21 @@ const yaml = require('js-yaml');
  */
 async function prepareExecutionConfig(task, conf) {
   // Find the task config from our config path. If this doesn't exist, we can't continue
-  console.log('--- preparing execution config:');
+  console.log("--- preparing execution config:");
   const taskConfig = await localTaskConfig(task, conf);
   console.dir(taskConfig);
   if (taskConfig == null) {
-    return { error: 'task-config-not-found' };
+    return { error: "task-config-not-found" };
   }
 
   if (taskConfig.worker == null) {
-    return { error: 'task-worker-config-not-found' };
+    return { error: "task-worker-config-not-found" };
   }
   const workerConfig = taskConfig.worker;
 
   // Check for required fields
   if (workerConfig.taskCommand == null) {
-    return { error: 'task-config-missing-task-command' };
+    return { error: "task-config-missing-task-command" };
   }
 
   return {
@@ -31,7 +31,7 @@ async function prepareExecutionConfig(task, conf) {
     taskCommand: workerConfig.taskCommand,
     taskArguments:
       workerConfig.taskArguments != null
-        ? workerConfig.taskArguments.split(' ')
+        ? workerConfig.taskArguments.split(" ")
         : [],
     gitClone:
       workerConfig.gitClone != null ? workerConfig.gitClone : conf.gitClone,
@@ -55,7 +55,11 @@ async function prepareExecutionConfig(task, conf) {
     successSummaryFile: workerConfig.successSummaryFile,
     successTextFile: workerConfig.successTextFile,
     errorSummaryFile: workerConfig.errorSummaryFile,
-    errorTextFile: workerConfig.errorTextFile
+    errorTextFile: workerConfig.errorTextFile,
+    taskTimeout:
+      workerConfig.taskTimeout != null
+        ? workerConfig.taskTimeout
+        : conf.taskTimeout
   };
 }
 
@@ -67,7 +71,7 @@ async function prepareExecutionConfig(task, conf) {
 async function localTaskConfig(task, conf) {
   try {
     const taskFileContents = fs.readFileSync(
-      conf.stampedeConfigPath + '/tasks/' + task.task.id + '.yaml'
+      conf.stampedeConfigPath + "/tasks/" + task.task.id + ".yaml"
     );
     if (taskFileContents == null) {
       return null;
@@ -75,7 +79,7 @@ async function localTaskConfig(task, conf) {
     const taskFile = yaml.safeLoad(taskFileContents);
     return taskFile;
   } catch (e) {
-    console.log('Error reading task config: ' + e);
+    console.log("Error reading task config: " + e);
     return null;
   }
 }


### PR DESCRIPTION
This PR introduces a `taskTimeout` worker config option for each task that will specify how many milliseconds the task can run until a timeout happens. The default is 30 minutes for a single task. When killed, the spawned executable is killed and the task is marked failed.

Closes #87 