### PR TITLE
♻️ Now getting task config from queue message

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -23,7 +23,6 @@ const conf = require("rc")("stampede", {
   redisPassword: null,
   nodeName: null,
   workerName: null,
-  stampedeConfigPath: null,
   stampedeScriptPath: null,
   taskQueue: "tasks",
   responseQueue: "response",
@@ -71,8 +70,6 @@ console.log(chalk.yellow(module.exports.version));
 console.log(chalk.red("Redis Host: " + conf.redisHost));
 console.log(chalk.red("Redis Port: " + conf.redisPort));
 console.log(chalk.red("Node Name: " + conf.nodeName));
-console.log(chalk.red("Config Path: " + conf.stampedeConfigPath));
-console.log(chalk.red("Script Path: " + conf.stampedeScriptPath));
 console.log(chalk.red("Task Queue: " + conf.taskQueue));
 console.log(chalk.red("Workspace Root: " + conf.workspaceRoot));
 console.log(chalk.red("Worker Name: " + conf.workerName));
@@ -83,7 +80,6 @@ if (
   conf.redisHost == null ||
   conf.redisPort == null ||
   conf.nodeName == null ||
-  conf.stampedeConfigPath == null ||
   conf.stampedeScriptPath == null ||
   conf.workspaceRoot == null
 ) {

--- a/lib/executionConfig.js
+++ b/lib/executionConfig.js
@@ -10,16 +10,8 @@ const yaml = require("js-yaml");
 async function prepareExecutionConfig(task, conf) {
   // Find the task config from our config path. If this doesn't exist, we can't continue
   console.log("--- preparing execution config:");
-  const taskConfig = await localTaskConfig(task, conf);
-  console.dir(taskConfig);
-  if (taskConfig == null) {
-    return { error: "task-config-not-found" };
-  }
-
-  if (taskConfig.worker == null) {
-    return { error: "task-worker-config-not-found" };
-  }
-  const workerConfig = taskConfig.worker;
+  const workerConfig = task.workerConfig;
+  console.dir(workerConfig)
 
   // Check for required fields
   if (workerConfig.taskCommand == null) {
@@ -61,27 +53,6 @@ async function prepareExecutionConfig(task, conf) {
         ? workerConfig.taskTimeout
         : conf.taskTimeout
   };
-}
-
-/**
- * localTaskConfig
- * @param {*} task
- * @param {*} conf
- */
-async function localTaskConfig(task, conf) {
-  try {
-    const taskFileContents = fs.readFileSync(
-      conf.stampedeConfigPath + "/tasks/" + task.task.id + ".yaml"
-    );
-    if (taskFileContents == null) {
-      return null;
-    }
-    const taskFile = yaml.safeLoad(taskFileContents);
-    return taskFile;
-  } catch (e) {
-    console.log("Error reading task config: " + e);
-    return null;
-  }
 }
 
 module.exports.prepareExecutionConfig = prepareExecutionConfig;


### PR DESCRIPTION
This PR changes where the worker gets the task config from. It was previously from the local file system, but now the config comes in the queue message itself. This is less burdensome on the admins since the worker no longer needs the task config to be on the worker machine.

closes #109 