### PR TITLE
✨ Support checking out to latest in a branch

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -69,20 +69,32 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf) {
       // Now checkout our head sha
       console.log(chalk.green("--- head"));
       console.dir(taskExecutionConfig.task.scm.pullRequest.head);
-      await gitCheckout(taskExecutionConfig.task.scm.pullRequest.head.sha, dir);
+      await gitCheckout(
+        taskExecutionConfig.task.scm.pullRequest.head.sha,
+        null,
+        dir
+      );
       // And then merge the base sha
       console.log(chalk.green("--- base"));
       console.dir(taskExecutionConfig.task.scm.pullRequest.base);
-      await gitMerge(taskExecutionConfig.task.scm.pullRequest.base.sha, dir);
+      await gitMerge(
+        taskExecutionConfig.task.scm.pullRequest.base.sha,
+        null,
+        dir
+      );
       // Fail if we have merge conflicts
     } else if (taskExecutionConfig.task.scm.branch != null) {
       console.log(chalk.green("--- sha"));
       console.dir(taskExecutionConfig.task.scm.branch.sha);
-      await gitCheckout(taskExecutionConfig.task.scm.branch.sha, dir);
+      await gitCheckout(
+        taskExecutionConfig.task.scm.branch.sha,
+        taskExecutionConfig.task.scm.branch.name,
+        dir
+      );
     } else if (taskExecutionConfig.task.scm.release != null) {
       console.log(chalk.green("--- sha"));
       console.dir(taskExecutionConfig.task.scm.release.sha);
-      await gitCheckout(taskExecutionConfig.task.scm.release.sha, dir);
+      await gitCheckout(taskExecutionConfig.task.scm.release.sha, null, dir);
     }
   } else {
     console.log(
@@ -121,12 +133,20 @@ async function cloneRepo(cloneUrl, workingDirectory, cloneOptions) {
 /**
  * Perform a git checkout of our branch
  * @param {*} sha
+ * @param {*} branch
  * @param {*} workingDirectory
  */
-async function gitCheckout(sha, workingDirectory) {
+async function gitCheckout(sha, branch, workingDirectory) {
+  let checkoutCommand = "";
+  if (sha === "latest") {
+    checkoutCommand = "git checkout " + branch;
+  } else {
+    checkoutCommand = "git checkout -f " + sha;
+  }
+
   return new Promise(resolve => {
     exec(
-      "git checkout -f " + sha,
+      checkoutCommand,
       { cwd: workingDirectory },
       (error, stdout, stderr) => {
         if (error) {


### PR DESCRIPTION
This PR modifies the `git checkout` logic and allows the worker to receive `latest` as a SHA and when received will perform a simple `git checkout branch` instead of checking out the specific SHA commit. Now jobs can be configured to pull the latest commit and not have to generate SHAs dynamically.

closes #115 