### PR TITLE
✨ New environment variables for PR details

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -439,6 +439,18 @@ function collectEnvironment(taskExecutionConfig, workingDirectory) {
       environment[
         taskExecutionConfig.environmentVariablePrefix + "GITSHAHEAD"
       ] = task.scm.pullRequest.head.sha;
+      environment[taskExecutionConfig.environmentVariablePrefix + "PRTITLE"] =
+        task.scm.pullRequest.title;
+      environment[
+        taskExecutionConfig.environmentVariablePrefix + "PRBODYLENGTH"
+      ] = task.scm.pullRequest.bodyLength;
+      environment[
+        taskExecutionConfig.environmentVariablePrefix + "PRMILESTONE"
+      ] = task.scm.pullRequest.milestone;
+      environment[taskExecutionConfig.environmentVariablePrefix + "PRLABELS"] =
+        task.scm.pullRequest.labels != null
+          ? task.scm.pullRequest.labels.join(",")
+          : "";
     }
 
     if (task.scm.branch != null) {


### PR DESCRIPTION
This PR adds new environment variables for pull requests so that tasks can use them. Title, body length, milestone and labels are now available as environment variables to tasks when the task was triggered from a pull request.

closes #117 