### PR TITLE
✨ now using access token for https clones

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -58,7 +58,10 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf) {
     } else if (conf.gitClone === "https") {
       console.log(chalk.green(taskExecutionConfig.task.scm.cloneURL));
       await cloneRepo(
-        taskExecutionConfig.task.scm.cloneURL,
+        taskExecutionConfig.task.scm.cloneURL.replace(
+          "https://",
+          "https://" + taskExecutionConfig.task.scm.accessToken + "@"
+        ),
         dir,
         taskExecutionConfig.gitCloneOptions
       );


### PR DESCRIPTION
This PR updates the worker to use the access token sent from the server when performing a https clone. This allows the system to clone a repo where the GitHub app has been granted permission without having to grant a specific user access and cloning via ssh. Now both are possible depending on the repo and setup desired.

closes #122