### PR TITLE
✨ Now returning clone errors as a failed task

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -50,14 +50,17 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf) {
     console.log(chalk.green("--- performing a git clone from:"));
     if (taskExecutionConfig.gitClone === "ssh") {
       console.log(chalk.green(taskExecutionConfig.task.scm.sshURL));
-      await cloneRepo(
+      const cloneResult = await cloneRepo(
         taskExecutionConfig.task.scm.sshURL,
         dir,
         taskExecutionConfig.gitCloneOptions
       );
+      if (cloneResult === false) {
+        return null;
+      }
     } else if (conf.gitClone === "https") {
       console.log(chalk.green(taskExecutionConfig.task.scm.cloneURL));
-      await cloneRepo(
+      const cloneResult = await cloneRepo(
         taskExecutionConfig.task.scm.cloneURL.replace(
           "https://",
           "https://" + taskExecutionConfig.task.scm.accessToken + "@"
@@ -65,6 +68,9 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf) {
         dir,
         taskExecutionConfig.gitCloneOptions
       );
+      if (cloneResult === false) {
+        return null;
+      }
     }
 
     // Handle pull requests differently
@@ -127,7 +133,7 @@ async function cloneRepo(cloneUrl, workingDirectory, cloneOptions) {
         }
         console.log(`stdout: ${stdout}`);
         console.log(`stderr: ${stderr}`);
-        resolve(false);
+        resolve(true);
       }
     );
   });


### PR DESCRIPTION
This PR now returns a task failure if we get a clone error. Before it would continue with the task and possibly not fail in a clear way.

closes #125