### PR TITLE
🐛 fixed bug in gitmerge method

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -94,7 +94,6 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
       );
       await gitMerge(
         taskExecutionConfig.task.scm.pullRequest.base.sha,
-        null,
         dir,
         logger
       );
@@ -198,7 +197,6 @@ async function gitMerge(sha, workingDirectory, logger) {
       (error, stdout, stderr) => {
         if (error) {
           logger.error(`gitMerge error: ${error}`);
-          // TODO: figure out the error reason
           resolve(false);
           return;
         }


### PR DESCRIPTION
This PR fixes a bug found in the gitMerge method that causes the task to fail silently.