### PR TITLE
✨ Now writing out the release body to a file if received

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -45,6 +45,7 @@ const conf = require("rc")("stampede", {
   // Log file configuration
   environmentLogFile: "environment.log",
   taskDetailsLogFile: "worker.log",
+  releaseBodyFile: "releasebody.txt",
   logQueuePath: null,
   // Heartbeat
   heartbeatInterval: 15000
@@ -215,6 +216,23 @@ async function handleTask(task, responseQueue) {
         );
       } catch (e) {
         logger.error("Error writing environment log: " + e);
+      }
+    }
+
+    // Write out release body if found
+    if (
+      conf.releaseBodyFile != null &&
+      taskExecutionConfig.task.scm.release != null &&
+      taskExecutionConfig.task.scm.release.body != null
+    ) {
+      logger.verbose("Writing out release body");
+      try {
+        fs.writeFileSync(
+          directory + "/" + conf.releaseBodyFile,
+          taskExecutionConfig.task.scm.release.body
+        );
+      } catch (e) {
+        logger.error("Error writing release body: " + e);
       }
     }
 


### PR DESCRIPTION
This PR looks for a release body in the task details and will write it out to a file for shell based tasks. The default filename is `releasebody.txt`. Given that release notes can be quite extensive, it is best not written to an environment variable, but directly to a file. Also many tools where release notes are used can read directly from files anyway.

closes #133 
