### PR TITLE
🐛 Fixed issue when cloning using https

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -38,7 +38,7 @@ const conf = require("rc")("stampede", {
   // Task defaults
   environmentVariablePrefix: "STAMP_",
   shell: "/bin/bash",
-  gitClone: "ssh",
+  gitClone: "https",
   gitCloneOptions: "",
   stdoutLogFile: "stdout.log",
   stderrLogFile: null,

--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -58,12 +58,14 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
       if (cloneResult === false) {
         return null;
       }
-    } else if (conf.gitClone === "https") {
+    } else if (taskExecutionConfig.gitClone === "https") {
       logger.verbose(taskExecutionConfig.task.scm.cloneURL);
       const cloneResult = await cloneRepo(
         taskExecutionConfig.task.scm.cloneURL.replace(
           "https://",
-          "https://" + taskExecutionConfig.task.scm.accessToken + "@"
+          "https://x-access-token:" +
+            taskExecutionConfig.task.scm.accessToken +
+            "@"
         ),
         dir,
         taskExecutionConfig.gitCloneOptions,
@@ -133,7 +135,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
  * @param {*} workingDirectory
  */
 async function cloneRepo(cloneUrl, workingDirectory, cloneOptions, logger) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     exec(
       "git clone " + cloneOptions + " " + cloneUrl + " " + workingDirectory,
       (error, stdout, stderr) => {
@@ -165,7 +167,7 @@ async function gitCheckout(sha, branch, workingDirectory, logger) {
     checkoutCommand = "git checkout -f " + sha;
   }
 
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     exec(
       checkoutCommand,
       { cwd: workingDirectory },
@@ -190,7 +192,7 @@ async function gitCheckout(sha, branch, workingDirectory, logger) {
  * @param {*} workingDirectory
  */
 async function gitMerge(sha, workingDirectory, logger) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     exec(
       "git merge " + sha,
       { cwd: workingDirectory },
@@ -209,7 +211,7 @@ async function gitMerge(sha, workingDirectory, logger) {
 }
 
 async function mkdir(dir, logger) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     exec("mkdir -p " + dir, (error, stdout, stderr) => {
       if (error) {
         logger.error(`mkdir error: ${error}`);


### PR DESCRIPTION
This PR fixes a bug when trying to clone using the access token. Also makes https cloning the default.

closes #141 