### PR TITLE
♻️ Use name not sha for merging from base

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -95,7 +95,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
         JSON.stringify(taskExecutionConfig.task.scm.pullRequest.base)
       );
       await gitMerge(
-        taskExecutionConfig.task.scm.pullRequest.base.sha,
+        taskExecutionConfig.task.scm.pullRequest.base.ref,
         dir,
         logger
       );


### PR DESCRIPTION
This PR changes the merge behavior when cloning PRs. Now the system will use the base branch name and not the sha. Unfortunately we can't trust the sha to always be the latest for the base. This might get locked to a single sha when the PR is created, not sure.

closes #143 
