### PR TITLE
🐛Fixed missing finished at date for working folder failures

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -180,8 +180,7 @@ async function handleTask(task, responseQueue) {
         conclusion: "failure",
         summary: taskExecutionConfig.error,
       };
-      const finishedAt = new Date();
-      task.stats.finishedAt = finishedAt;
+      task.stats.finishedAt = new Date();
       await updateTask(task, responseQueue);
       workerStatus = "idle";
       return;
@@ -200,8 +199,7 @@ async function handleTask(task, responseQueue) {
         conclusion: "failure",
         summary: "Working directory error",
       };
-      const finishedAt = new Date();
-      task.stats.finishedAt = finishedAt;
+      task.stats.finishedAt = new Date();
       await updateTask(task, responseQueue);
       workerStatus = "idle";
       return;

--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -180,6 +180,8 @@ async function handleTask(task, responseQueue) {
         conclusion: "failure",
         summary: taskExecutionConfig.error,
       };
+      const finishedAt = new Date();
+      task.stats.finishedAt = finishedAt;
       await updateTask(task, responseQueue);
       workerStatus = "idle";
       return;
@@ -198,6 +200,8 @@ async function handleTask(task, responseQueue) {
         conclusion: "failure",
         summary: "Working directory error",
       };
+      const finishedAt = new Date();
+      task.stats.finishedAt = finishedAt;
       await updateTask(task, responseQueue);
       workerStatus = "idle";
       return;


### PR DESCRIPTION
This PR fixes an issue where the task wouldn't get a finished_at date when there was an issue cloning into the working folder. This cases the tasks not to show up in certain places in the UI since it filters by finished at dates.