### PR TITLE
👷‍♂️ Write out a clone error log

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -141,7 +141,24 @@ async function cloneRepo(cloneUrl, workingDirectory, cloneOptions, logger) {
       (error, stdout, stderr) => {
         if (error) {
           logger.error(`cloneRepo error: ${error}`);
-          // TODO: figure out the error reason
+          try {
+            const cloneErrorLog =
+              "cloneRepo error: " +
+              error +
+              "\n" +
+              "stdout: " +
+              stdout +
+              "\n" +
+              "stderr: " +
+              stderr +
+              "\n";
+            fs.writeFileSync(
+              workingDirectory + "/cloneerror.log",
+              cloneErrorLog
+            );
+          } catch (e) {
+            logger.error(`error writing out clone log: ` + e);
+          }
           resolve(false);
           return;
         }


### PR DESCRIPTION
This PR adds an error log written to the workspace when the clone fails for some reason. This allows for easier debugging instead of trying to find it in the worker logs.

closes #147 