### PR TITLE
👷‍♂️ Fail more clearly for git clone and merge errors

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -202,7 +202,55 @@ async function handleTask(task, responseQueue) {
       await updateTask(task, responseQueue);
       workerStatus = "idle";
       return;
+    } else if (directory === "mkdir-error") {
+      logger.error("Error creating working directory");
+      task.status = "completed";
+      task.result = {
+        conclusion: "failure",
+        summary:
+          "Unable to create working directory, please contact the service desk and report the issue.",
+      };
+      task.stats.finishedAt = new Date();
+      await updateTask(task, responseQueue);
+      workerStatus = "idle";
+      return;
+    } else if (directory === "clone-error") {
+      logger.error("Error cloning repository");
+      task.status = "completed";
+      task.result = {
+        conclusion: "failure",
+        summary:
+          "Unable to clone the repository, please contact the service desk and report the issue.",
+      };
+      task.stats.finishedAt = new Date();
+      await updateTask(task, responseQueue);
+      workerStatus = "idle";
+      return;
+    } else if (directory === "checkout-error") {
+      logger.error("Error checking out commit");
+      task.status = "completed";
+      task.result = {
+        conclusion: "failure",
+        summary: "Unable to perform a git checkout to this git commit",
+      };
+      task.stats.finishedAt = new Date();
+      await updateTask(task, responseQueue);
+      workerStatus = "idle";
+      return;
+    } else if (directory === "merge-error") {
+      logger.error("Error merging from base branch");
+      task.status = "completed";
+      task.result = {
+        conclusion: "failure",
+        summary:
+          "Unable to merge from the base branch, solve the merge conflict so the task can run.",
+      };
+      task.stats.finishedAt = new Date();
+      await updateTask(task, responseQueue);
+      workerStatus = "idle";
+      return;
     }
+
     task.worker.directory = directory;
 
     // Setup our environment variables

--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -36,7 +36,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
     const mkdirResult = await mkdir(dir, logger);
     if (!mkdirResult) {
       logger.error("Error making the directory, unable to continue!");
-      return null;
+      return "mkdir-error";
     }
   }
   logger.verbose("working directory: " + dir);
@@ -56,7 +56,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
         logger
       );
       if (cloneResult === false) {
-        return null;
+        return "clone-error";
       }
     } else if (taskExecutionConfig.gitClone === "https") {
       logger.verbose(taskExecutionConfig.task.scm.cloneURL);
@@ -72,7 +72,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
         logger
       );
       if (cloneResult === false) {
-        return null;
+        return "clone-error";
       }
     }
 
@@ -83,43 +83,54 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
       logger.verbose(
         JSON.stringify(taskExecutionConfig.task.scm.pullRequest.head, null, 2)
       );
-      await gitCheckout(
+      const checkoutResult = await gitCheckout(
         taskExecutionConfig.task.scm.pullRequest.head.sha,
         null,
         dir,
         logger
       );
+      if (checkoutResult === false) {
+        return "checkout-error";
+      }
       // And then merge the base sha
       logger.verbose("base");
       logger.verbose(
         JSON.stringify(taskExecutionConfig.task.scm.pullRequest.base)
       );
-      await gitMerge(
+      const mergeResult = await gitMerge(
         taskExecutionConfig.task.scm.pullRequest.base.ref,
         dir,
         logger
       );
-      // Fail if we have merge conflicts
+      if (mergeResult === false) {
+        return "merge-error";
+      }
     } else if (taskExecutionConfig.task.scm.branch != null) {
       logger.verbose("sha");
       logger.verbose(JSON.stringify(taskExecutionConfig.task.scm.branch.sha));
-      await gitCheckout(
+      const checkoutResult = await gitCheckout(
         taskExecutionConfig.task.scm.branch.sha,
         taskExecutionConfig.task.scm.branch.name,
         dir,
         logger
       );
+      if (checkoutResult === false) {
+        return "checkout-error";
+      }
     } else if (taskExecutionConfig.task.scm.release != null) {
       logger.verbose("sha");
       logger.verbose(
         JSON.stringify(taskExecutionConfig.task.scm.release.sha, null, 2)
       );
-      await gitCheckout(
+      const checkoutResult = await gitCheckout(
         taskExecutionConfig.task.scm.release.sha,
         null,
         dir,
         logger
       );
+      if (checkoutResult === false) {
+        return "checkout-error";
+      }
     }
   } else {
     logger.verbose(

--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -202,13 +202,12 @@ async function gitCheckout(sha, branch, workingDirectory, logger) {
       (error, stdout, stderr) => {
         if (error) {
           logger.error(`gitCheckout error: ${error}`);
-          // TODO: figure out the error reason
           resolve(false);
           return;
         }
         logger.verbose(`stdout: ${stdout}`);
         logger.verbose(`stderr: ${stderr}`);
-        resolve(false);
+        resolve(true);
       }
     );
   });
@@ -232,7 +231,7 @@ async function gitMerge(sha, workingDirectory, logger) {
         }
         logger.verbose(`stdout: ${stdout}`);
         logger.verbose(`stderr: ${stderr}`);
-        resolve(false);
+        resolve(true);
       }
     );
   });

--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -76,7 +76,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
       }
     }
 
-    // Handle pull requests differently
+    // For PRs we need to do a checkout & merge
     if (taskExecutionConfig.task.scm.pullRequest != null) {
       // Now checkout our head sha
       logger.verbose("head");


### PR DESCRIPTION
This PR changes the behavior when performing the git clone, checkout and merge commands. Now they are all checked for failure and will fail the task with a more descriptive error instead of letting the command attempt to execute and produce confusing or possibly invalid results.

closes #144 