### PR TITLE
🔊Added commit details logging

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -142,6 +142,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
       }
       if (taskExecutionConfig.task.scm.branch.sha === "latest") {
         const details = await commitDetails(dir, logger);
+        logger.verbose(JSON.stringify(details, null, 2));
         return {
           directory: dir,
           error: null,


### PR DESCRIPTION
This PR adds verbose logging for the commit details for a branch checkout. These details are used to fill in the gaps if the task was started based on the latest commit of a branch.