### PR TITLE
♻️ Use subject instead of body for commit message

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -147,7 +147,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
           directory: dir,
           error: null,
           sha: details != null ? details.hash : null,
-          commit: details != null ? details.body : null,
+          commit: details != null ? details.subject : null,
         };
       }
     } else if (taskExecutionConfig.task.scm.release != null) {


### PR DESCRIPTION
This PR changes the commit message to use subject instead of body when capturing the commit details from a branch task and latest commit.

closes #163 