### PR TITLE
✨ Improved graceful shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .DS_Store
-.stampederc
+.stampederc*
 .*rc
 startWorkers.sh
 stopWorkers.sh

--- a/.ubolt.yaml
+++ b/.ubolt.yaml
@@ -12,3 +12,6 @@ newversion:
 version:
   command: npm view stampede-worker version
   description: Show the current version of the package
+runlocal:
+  command: bin/stampede-worker.js --config .stampederc-local
+  description: Run worker locally against test docker containers


### PR DESCRIPTION
This PR adds more logic to the graceful shutdown to handle when a task is currently running. Now the worker will stop the task, update it back to `queued` and then stop the worker. This allows the task to be processed by a separate worker. To gracefully shutdown and re-queue the task, a SIGHUP signal must be sent to the worker, not SIGKILL or SIGINT. You can still send the latter 2 if you don't care about the currently running task.

closes #176 
