### PR TITLE
✨ Worker now returns metadata & artifact contents if specified

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -326,7 +326,7 @@ async function handleTask(task, responseQueue) {
               "Error reading contents json file: " +
                 directory +
                 "/" +
-                task.result.artifacts[aindex].metadata_file +
+                task.result.artifacts[aindex].contents_file +
                 " " +
                 e
             );

--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -294,21 +294,43 @@ async function handleTask(task, responseQueue) {
     if (task.result.artifacts != null) {
       for (let aindex = 0; aindex < task.result.artifacts.length; aindex++) {
         if (task.result.artifacts[aindex].metadata_file != null) {
-          const metadata = JSON.parse(
-            fs.readFileSync(
-              directory + "/" + task.result.artifacts[aindex].metadata_file
-            )
-          );
-          task.result.artifacts[aindex].metadata = metadata;
+          try {
+            const metadata = JSON.parse(
+              fs.readFileSync(
+                directory + "/" + task.result.artifacts[aindex].metadata_file
+              )
+            );
+            task.result.artifacts[aindex].metadata = metadata;
+          } catch (e) {
+            logger.error(
+              "Error reading metadata json file: " +
+                directory +
+                "/" +
+                task.result.artifacts[aindex].metadata_file +
+                " " +
+                e
+            );
+          }
         }
 
         if (task.result.artifacts[aindex].contents_file != null) {
-          const contents = JSON.parse(
-            fs.readFileSync(
-              directory + "/" + task.result.artifacts[aindex].contents_file
-            )
-          );
-          task.result.artifacts[aindex].contents = contents;
+          try {
+            const contents = JSON.parse(
+              fs.readFileSync(
+                directory + "/" + task.result.artifacts[aindex].contents_file
+              )
+            );
+            task.result.artifacts[aindex].contents = contents;
+          } catch (e) {
+            logger.error(
+              "Error reading contents json file: " +
+                directory +
+                "/" +
+                task.result.artifacts[aindex].metadata_file +
+                " " +
+                e
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
This PR Updates the worker to allow for loading contents & metadata for artifacts that specify json files for these. This allows Stampede to store certain contents in its database directly instead of relying solely on external file hosting. Storing contents is limited to JSON documents and care should be taken to not store huge amounts of data. But for most use-cases this shouldn't be a problem.

closes #180 