### PR TITLE
🐛 Set working directory to known good directory before exec operations

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -34,7 +34,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
     taskExecutionConfig.task.task.number;
 
   if (!fs.existsSync(dir)) {
-    const mkdirResult = await mkdir(dir, logger);
+    const mkdirResult = await mkdir(dir, logger, conf.workspaceRoot);
     if (!mkdirResult) {
       logger.error("Error making the directory, unable to continue!");
       return {
@@ -58,7 +58,8 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
         taskExecutionConfig.task.scm.sshURL,
         dir,
         taskExecutionConfig.gitCloneOptions,
-        logger
+        logger,
+        conf.workspaceRoot
       );
       if (cloneResult === false) {
         return {
@@ -78,7 +79,8 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
         ),
         dir,
         taskExecutionConfig.gitCloneOptions,
-        logger
+        logger,
+        conf.workspaceRoot
       );
       if (cloneResult === false) {
         return {
@@ -186,10 +188,17 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
  * @param {*} cloneUrl
  * @param {*} workingDirectory
  */
-async function cloneRepo(cloneUrl, workingDirectory, cloneOptions, logger) {
+async function cloneRepo(
+  cloneUrl,
+  workingDirectory,
+  cloneOptions,
+  logger,
+  workspaceRoot
+) {
   return new Promise((resolve) => {
     exec(
       "git clone " + cloneOptions + " " + cloneUrl + " " + workingDirectory,
+      { cwd: workspaceRoot },
       (error, stdout, stderr) => {
         if (error) {
           logger.error(`cloneRepo error: ${error}`);
@@ -278,9 +287,9 @@ async function gitMerge(sha, workingDirectory, logger) {
   });
 }
 
-async function mkdir(dir, logger) {
+async function mkdir(dir, logger, workspaceRoot) {
   return new Promise((resolve) => {
-    exec("mkdir -p " + dir, (error, stdout, stderr) => {
+    exec("mkdir -p " + dir, { cwd: workspaceRoot }, (error, stdout, stderr) => {
       if (error) {
         logger.error(`mkdir error: ${error}`);
         resolve(false);


### PR DESCRIPTION
This PR updates the operations for making the working folder and cloning the repo so they have their working directory set to the workspace root. If the process somehow gets its working directory changed, these operations can fail with an error: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory. This should no longer happen since the workspace root should always be there.

Closes #175 but not really a timing error.