### PR TITLE
🐛 Fixed bug trying to get last commit for release clones

### DIFF
--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -98,7 +98,7 @@ async function prepareWorkingDirectory(taskExecutionConfig, conf, logger) {
   }
 
   // Perform the checkout
-  if (gitOperations.sha != null) {
+  if (gitOperations.shouldCheckout == true && gitOperations.sha != null) {
     const checkoutResult = await gitCheckout(gitOperations.sha, dir, logger);
     if (checkoutResult === false) {
       return {
@@ -317,6 +317,7 @@ function generateGitOperations(taskExecutionConfig, conf) {
     return {
       clone: taskExecutionConfig.task.scm.pullRequest.head.ref,
       sha: taskExecutionConfig.task.scm.pullRequest.head.sha,
+      shouldCheckout: true,
       depth: parseInt(conf.defaultGitCloneDepth),
       merge: conf.gitMerge,
       mergeBase: taskExecutionConfig.task.scm.pullRequest.base.ref,
@@ -326,6 +327,7 @@ function generateGitOperations(taskExecutionConfig, conf) {
       return {
         clone: taskExecutionConfig.task.scm.branch.name,
         sha: null,
+        shouldCheckout: false,
         depth: parseInt(conf.defaultGitCloneDepth),
         merge: false,
       };
@@ -333,6 +335,7 @@ function generateGitOperations(taskExecutionConfig, conf) {
       return {
         clone: taskExecutionConfig.task.scm.branch.name,
         sha: taskExecutionConfig.task.scm.branch.sha,
+        shouldCheckout: true,
         depth: parseInt(conf.defaultGitCloneDepth),
         merge: false,
       };
@@ -340,7 +343,8 @@ function generateGitOperations(taskExecutionConfig, conf) {
   } else if (taskExecutionConfig.task.scm.release != null) {
     return {
       clone: taskExecutionConfig.task.scm.release.tag,
-      sha: null,
+      sha: taskExecutionConfig.task.scm.release.sha,
+      shouldCheckout: false,
       depth: parseInt(conf.defaultGitCloneDepth),
       merge: false,
     };


### PR DESCRIPTION
This PR fixes a bug that was causing an error after getting the last commit details for a release task: 

```
Error in handle task TypeError: Cannot set property 'sha' of undefined
```

closes #189 