### PR TITLE
Modified some debugging info, appended attributes from task.config in…

### DIFF
--- a/bin/stampede-worker.js
+++ b/bin/stampede-worker.js
@@ -599,7 +599,7 @@ function collectEnvironment(taskExecutionConfig, workingDirectory) {
   logger.verbose(JSON.stringify(task.config, null, 2));
   if (task.config != null) {
     Object.keys(task.config).forEach(function (key) {
-      logger.verbose("key: " + key);
+      logger.verbose("task.config key: " + key);
       const envVar =
         taskExecutionConfig.environmentVariablePrefix + key.toUpperCase();
       environment[envVar] = task.config[key].value;

--- a/lib/executionConfig.js
+++ b/lib/executionConfig.js
@@ -10,7 +10,7 @@ const yaml = require("js-yaml");
 async function prepareExecutionConfig(task, conf, logger) {
   // Find the task config from our config path. If this doesn't exist, we can't continue
   logger.verbose("preparing execution config:");
-  const workerConfig = task.workerConfig;
+  let workerConfig = task.workerConfig;
   if ("config" in task) {
     Object.keys(task.config).forEach(key => {
       if ("value" in task.config[key]) {

--- a/lib/executionConfig.js
+++ b/lib/executionConfig.js
@@ -11,13 +11,19 @@ async function prepareExecutionConfig(task, conf, logger) {
   // Find the task config from our config path. If this doesn't exist, we can't continue
   logger.verbose("preparing execution config:");
   const workerConfig = task.workerConfig;
+  if ("config" in task) {
+    Object.keys(task.config).forEach(key => {
+      if ("value" in task.config[key]) {
+        workerConfig[key] = task.config[key].value;
+      }
+    })
+  }
   logger.verbose(JSON.stringify(workerConfig, null, 2));
 
   // Check for required fields
   if (workerConfig.taskCommand == null) {
     return { error: "task-config-missing-task-command" };
   }
-
   return {
     task: task,
     taskCommand: workerConfig.taskCommand,

--- a/lib/workingDirectory.js
+++ b/lib/workingDirectory.js
@@ -199,7 +199,7 @@ async function cloneRepo(
     cloneUrl +
     " " +
     workingDirectory;
-  logger.verbose("clone: " + cloneCommand);
+  logger.info("clone: " + cloneCommand);
   return new Promise((resolve) => {
     let success = true;
     exec(cloneCommand, { cwd: workspaceRoot }, (error, stdout, stderr) => {


### PR DESCRIPTION
Modified some debugging info, appended attributes from task.config into task.workerConfig since task attributes were being missed that we needed.

@davidahouse I found that task config parameters defined in stampede admin are not assigned to the workerConfig object in the task config, when executing the function prepareExecutionConfig.

At present, the only attribute that is evaluated is the "workerConfig" within the task object.  For example:

`{
    ...
    "config": {
      "projectFolder": {
        "value": ".",
        "source": "repoConfig"
      },
      "variant": {
        "value": "Debug",
        "source": "repoConfig"
      },
      "java_version": {
        "value": 11,
        "source": "repoConfig"
      },
      "gitCloneOptions": {
        "value": "--filter=tree:0",
        "source": "systemOverride"
      },
      "taskTimeout": {
        "value": 60000,
        "source": "systemDefault"
      }
    },
    "workerConfig": {
      "taskCommand": "stamp-unit-tests-android.sh",
      "successSummaryFile": "summary.md",
      "successTextFile": "text.md",
      "errorSummaryFile": "summary.md",
      "errorTextFile": "text.md",
      "stderrLogFile": "stderr.log"
    },
    ...
  }`

This patch will append the "value" attribute of each "config" option to be appended to the workerConfig, so some key overrides happen within stampede-worker.

We want to be able to override gitCloneOptions within the task definition, as well as the taskTimeout value, so certain tasks can run longer.

Maybe this is not the correct approach, but it seems like what was intended when testing for those values later in the prepareExecutionConfig function, those values would have never been populated in the workerConfig attribute but in the config attribute.  

The result being:

`{
  taskCommand: 'stamp-unit-tests-android.sh',
  successSummaryFile: 'summary.md',
  successTextFile: 'text.md',
  errorSummaryFile: 'summary.md',
  errorTextFile: 'text.md',
  stderrLogFile: 'stderr.log',
  projectFolder: '.',
  variant: 'Debug',
  java_version: 11,
  gitCloneOptions: '--filter=tree:0',
  taskTimeout: 60000
}`

I could specify just the two attributes that we need instead of looping over the whole "config" attribute.  However, this could provide us more flexibility in the future to change more of the tested values in the prepareExecutionConfig function.  There are some values in "config" that we will never need (java_version, projectFolder, etc), but they do not overlap/conflict w/ "workerConfig" and the operation of stampede-worker.

If you think this is in error, please let me know!
Thomas